### PR TITLE
Fix crash

### DIFF
--- a/RoboReader/Classes/RoboMainPagebar.m
+++ b/RoboReader/Classes/RoboMainPagebar.m
@@ -348,7 +348,9 @@
             currentPage = [document.pageCount floatValue];
         //currentSliderPage = currentPage;
 
-        float sliderRatio = (pagebarOffset - pagebarSlider.minimumValue) / (pagebarSlider.maximumValue - pagebarSlider.minimumValue);
+        float sliderRatio = 0;
+        if (pagebarSlider.maximumValue != pagebarSlider.minimumValue)
+            sliderRatio = (pagebarOffset - pagebarSlider.minimumValue) / (pagebarSlider.maximumValue - pagebarSlider.minimumValue);
         if (sliderRatio < 0)
             sliderRatio = 0;
         if (sliderRatio > 1)


### PR DESCRIPTION
In some cases, pagebarSlider.maximumValue and pagebarSlider.minimumValue can be equal so sliderRatio become NaN and application crashes.
